### PR TITLE
[feat] Allow plugins to use web workers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -995,7 +995,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -2724,7 +2724,7 @@
     },
     "json5": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
         "minimist": "1.2.0"
@@ -2732,7 +2732,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -3056,7 +3056,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
@@ -3113,7 +3113,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3610,7 +3610,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -5652,6 +5652,26 @@
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "requires": {
         "errno": "0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "requires": {
+        "loader-utils": "1.2.1",
+        "schema-utils": "0.4.7"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "requires": {
+            "ajv": "6.6.2",
+            "ajv-keywords": "3.2.0"
+          }
+        }
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "sass-loader": "^7.1.0",
     "underscore": "^1.9.1",
     "webpack": "^4.37.0",
-    "webpack-merge": "^4.2.1"
+    "webpack-merge": "^4.2.1",
+    "worker-loader": "^2.0.0"
   },
   "engines": {
     "node": "*"

--- a/webpack.config-options.js
+++ b/webpack.config-options.js
@@ -54,6 +54,14 @@ var baseConfigs = {
         test: /jquery.+\.js$/,
         use: 'ep_webpack/node_modules/imports-loader?define=>false',
       },
+      // Allow usage of web workers by the plugins. Their name should be *.worker.js
+      {
+        test: /\.worker\.js$/,
+        use: {
+          loader: 'worker-loader',
+          options: { inline: true },
+        }
+      },
     ],
   },
 };


### PR DESCRIPTION
Bundle web workers with file names ending with `.worker.js`.

For now web workers are bundled as inline code, but in the future we might try somthing like [`worker-plugin` lib](https://www.npmjs.com/package/worker-plugin) to allow a more flexible bundling.

# Full list of PRs of this feature:

- https://github.com/storytouch/ep_webpack/pull/14
- https://github.com/storytouch/ep_script_autocomp/pull/15
- https://github.com/storytouch/ep_script_line_size/pull/1
- https://github.com/storytouch/ep_script_line_size/pull/2
- https://github.com/storytouch/ep_script_page_view/pull/17
- https://github.com/storytouch/ep_draganddrop/pull/8
- https://github.com/storytouch/ep_script_scene_marks/pull/73
- https://github.com/storytouch/ep_script_copy_cut_paste/pull/34
- https://github.com/storytouch/etherpad-docker/pull/59
