### PR TITLE
[test] Allows to set custom options on pad creation

### DIFF
--- a/static/tests/frontend/specs/fixJqueryOnPadChrome.js
+++ b/static/tests/frontend/specs/fixJqueryOnPadChrome.js
@@ -1,8 +1,8 @@
 // override method to create pads, so we can inject the bundled jQuery on padChrome$
 var _newPad = helper.newPad;
 
-helper.newPad = function(cb, padName) {
-  return _newPad(function() {
+helper.newPad = function(cb, padName, opts) {
+  var customCb = function() {
     // get the bundled jQuery and inject it into padChrome$
     var thisPlugin = helper.padChrome$.window.pad.plugins.ep_webpack;
 
@@ -19,5 +19,10 @@ helper.newPad = function(cb, padName) {
     }
 
     cb();
-  }, padName);
-}
+  };
+
+  opts = opts || {};
+  opts.cb = customCb;
+
+  _newPad(opts, padName);
+};


### PR DESCRIPTION
As we override the default `helper.newPad` function, this PR allows proxy custom options to the pad creation helper.

**Usage:**
```js
var cb        = function() { /* ... */ }
var padName   = "New Pad"
var urlParams = { padType: "AnyType" }
var options   = { urlParams: urlParams } 

helper.newPad(cb, padName, options)
```