### PR TITLE
[fix] Fixes for Etherpad version 1.8.6 - squashable

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -4,10 +4,10 @@ var webpack = require('webpack');
 var _ = require('underscore');
 
 var cssBundler = require('./cssBundler');
+var shared = require('./shared');
 
 var JS_INDEX = 'static/js/index.js';
 var DEFAULT_WEBPACK_CONFIG_FILE = './webpack.config-default.js';
-var WEBPACK_FILES_GENERATED_EVENT = 'webpack_files_generated';
 var CONFIG_FILES = [
   { minify: false, css: false, fileName: DEFAULT_WEBPACK_CONFIG_FILE },
   { minify: true , css: false, fileName: './webpack.config-withMinify.js' },
@@ -15,7 +15,6 @@ var CONFIG_FILES = [
   { minify: true , css: true , fileName: './webpack.config-withMinifyAndCss.js' },
 ];
 
-exports.WEBPACK_FILES_GENERATED_EVENT = WEBPACK_FILES_GENERATED_EVENT;
 var isProduction = process.env.NODE_ENV !== 'development';
 
 exports.generateBundle = function(pluginParts, settings, editorEmitter, done) {
@@ -60,8 +59,8 @@ exports.buildIndexAndGenerateBundle = function(pluginParts, settings, createFile
             // emit an event when the files generated are created. This check
             // may be useful to control when the service is ready to receive
             // requests
-            console.log('emitting the event ' + WEBPACK_FILES_GENERATED_EVENT);
-            editorEmitter.emit(WEBPACK_FILES_GENERATED_EVENT);
+            editorEmitter.emit(shared.WEBPACK_FILES_GENERATED_EVENT);
+
             done();
           });
         }

--- a/editorEventEmitter.js
+++ b/editorEventEmitter.js
@@ -1,0 +1,18 @@
+var eventEmitter = require('events');
+
+class editorEvent {
+  constructor() {
+    const instance = this.constructor.instance;
+    if (instance) {
+      return instance;
+    }
+
+    this.constructor.instance = this;
+    this.editorEmitter = new eventEmitter();
+  }
+
+  getEventEmitter() {
+    return this.editorEmitter;
+  }
+}
+exports.editorEvent = editorEvent;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var plugins = require('ep_etherpad-lite/static/js/pluginfw/plugins');
+var pluginDefs = require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
 var pluginUtils = require('ep_etherpad-lite/static/js/pluginfw/shared');
 var bundler = require('./bundler');
 
@@ -8,9 +9,9 @@ exports.pluginUninstall = function(hook, context) {}
 exports.pluginInstall = function(hook, context) {}
 
 // build bundle for the first time
-exports.loadSettings = function(hook, context) {
+exports.loadSettings = async function(hook, context) {
   // store a copy of original plugin parts, so we can re-generate them later
-  originalParts = deepCopyOf(plugins.parts);
+  originalParts = deepCopyOf(pluginDefs.parts);
 
   buildBundle(context.settings);
 }
@@ -21,17 +22,17 @@ var deepCopyOf = function(obj) {
 
 var buildBundle = function(settings) {
   // restore original plugin parts, so we can re-generate using them as reference
-  plugins.parts = deepCopyOf(originalParts);
+  pluginDefs.parts = deepCopyOf(originalParts);
 
   console.log("ep_webpack: starting to generate bundle...");
-  bundler.generateBundle(plugins.parts, settings, function(err) {
+  bundler.generateBundle(pluginDefs.parts, settings, function(err) {
     // TODO handle error when generating bundle
     if (err) {
       throw err;
     } else {
       // re-generate hooks, so the new source is retrieved when pad is loaded.
-      // This line was copied from `plugins.update()`.
-      plugins.hooks = pluginUtils.extractHooks(plugins.parts, "hooks", plugins.pathNormalization);
+      // This line was copied from `pluginDefs.update()`.
+      pluginDefs.hooks = pluginUtils.extractHooks(pluginDefs.parts, "hooks", plugins.pathNormalization);
     }
 
     console.log("ep_webpack: bundle completed!");

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ var buildBundle = function(settings) {
   bundler.generateBundle(pluginDefs.parts, settings, function(err) {
     // TODO handle error when generating bundle
     if (err) {
+      console.log('******************** deu ruim!******************** deu ruim!');
+      console.log({err});
       throw err;
     } else {
       // re-generate hooks, so the new source is retrieved when pad is loaded.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,14 @@
+var eventEmitter = require('events');
+
 var plugins = require('ep_etherpad-lite/static/js/pluginfw/plugins');
 var pluginDefs = require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
 var pluginUtils = require('ep_etherpad-lite/static/js/pluginfw/shared');
 var bundler = require('./bundler');
+
+var thisEditorEmitter;
+exports.editorEmitter = function editorEmitter() {
+   return thisEditorEmitter;
+};
 
 // rebuild bundles
 // TODO implement them
@@ -10,26 +17,26 @@ exports.pluginInstall = function(hook, context) {}
 
 // build bundle for the first time
 exports.loadSettings = async function(hook, context) {
+  thisEditorEmitter = new eventEmitter();
+
   // store a copy of original plugin parts, so we can re-generate them later
   originalParts = deepCopyOf(pluginDefs.parts);
 
-  buildBundle(context.settings);
+  buildBundle(context.settings, thisEditorEmitter);
 }
 
 var deepCopyOf = function(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-var buildBundle = function(settings) {
+var buildBundle = function(settings, editorEmitter) {
   // restore original plugin parts, so we can re-generate using them as reference
   pluginDefs.parts = deepCopyOf(originalParts);
 
   console.log("ep_webpack: starting to generate bundle...");
-  bundler.generateBundle(pluginDefs.parts, settings, function(err) {
+  bundler.generateBundle(pluginDefs.parts, settings, editorEmitter, function(err) {
     // TODO handle error when generating bundle
     if (err) {
-      console.log('******************** deu ruim!******************** deu ruim!');
-      console.log({err});
       throw err;
     } else {
       // re-generate hooks, so the new source is retrieved when pad is loaded.

--- a/index.js
+++ b/index.js
@@ -1,39 +1,34 @@
-var eventEmitter = require('events');
-
 var plugins = require('ep_etherpad-lite/static/js/pluginfw/plugins');
 var pluginDefs = require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
 var pluginUtils = require('ep_etherpad-lite/static/js/pluginfw/shared');
 var bundler = require('./bundler');
-
-var thisEditorEmitter;
-exports.editorEmitter = function editorEmitter() {
-   return thisEditorEmitter;
-};
+var editorEvent = require('./editorEventEmitter').editorEvent;
 
 // rebuild bundles
 // TODO implement them
-exports.pluginUninstall = function(hook, context) {}
-exports.pluginInstall = function(hook, context) {}
+exports.pluginUninstall = function(hook, context) {};
+exports.pluginInstall = function(hook, context) {};
 
 // build bundle for the first time
-exports.loadSettings = async function(hook, context) {
-  thisEditorEmitter = new eventEmitter();
+exports.loadSettings = function(hook, context) {
+  // instantiate the singleton instance of the editor event emitter
+  var editorEmitter = new editorEvent().getEventEmitter();
 
   // store a copy of original plugin parts, so we can re-generate them later
   originalParts = deepCopyOf(pluginDefs.parts);
 
-  buildBundle(context.settings, thisEditorEmitter);
-}
+  buildBundle(context.settings, editorEmitter);
+};
 
 var deepCopyOf = function(obj) {
   return JSON.parse(JSON.stringify(obj));
-}
+};
 
 var buildBundle = function(settings, editorEmitter) {
   // restore original plugin parts, so we can re-generate using them as reference
   pluginDefs.parts = deepCopyOf(originalParts);
 
-  console.log("ep_webpack: starting to generate bundle...");
+  console.log('ep_webpack: starting to generate bundle...');
   bundler.generateBundle(pluginDefs.parts, settings, editorEmitter, function(err) {
     // TODO handle error when generating bundle
     if (err) {
@@ -41,9 +36,9 @@ var buildBundle = function(settings, editorEmitter) {
     } else {
       // re-generate hooks, so the new source is retrieved when pad is loaded.
       // This line was copied from `pluginDefs.update()`.
-      pluginDefs.hooks = pluginUtils.extractHooks(pluginDefs.parts, "hooks", plugins.pathNormalization);
+      pluginDefs.hooks = pluginUtils.extractHooks(pluginDefs.parts, 'hooks', plugins.pathNormalization);
     }
 
-    console.log("ep_webpack: bundle completed!");
+    console.log('ep_webpack: bundle completed!');
   });
-}
+};

--- a/shared.js
+++ b/shared.js
@@ -1,0 +1,1 @@
+exports.WEBPACK_FILES_GENERATED_EVENT = 'webpack_files_generated';


### PR DESCRIPTION
With the new version of Etherpad lots of stuff has changed! The main
changes was in the way plugins definitions are defined. With that PR
we make ep_webpack compatible with Etherpad 1.8.6

https://trello.com/c/AOBitW3b/2453

We implemented a mechanism of sending message when the webpack
is done.
https://trello.com/c/GUMf9dFp/2481-acertar-erro-do-webpack-no-deploy


related: https://github.com/storytouch/ep_connection_status/pull/2