### PR TITLE
[chore] Update node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "graceful-fs": "^4.2.0",
     "imports-loader": "^0.8.0",
     "mini-css-extract-plugin": "^0.5.0",
-    "node-sass": "^4.14.1",
+    "node-sass": "^6.0.0",
     "noop-webpack-plugin": "^1.0.1",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "sass-loader": "^7.1.0",


### PR DESCRIPTION
The node version of the etherpad-docker was upgraded to 16. The node-sass package must be updated accordingly.

[Go to card](https://trello.com/c/Odm5u3b0/3505-atualizar-vers%C3%A3o-do-node)